### PR TITLE
improve: use `numpy` method for w/r task cache instead `pickle`

### DIFF
--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -449,7 +449,6 @@ class Task(pl.LightningDataModule):
                     file_id,
                     segment.duration,
                     segment.start,
-                    segment.end,
                 )
                 annotated_regions.append(annotated_region)
 
@@ -530,7 +529,7 @@ class Task(pl.LightningDataModule):
         # turn list of files metadata into a single numpy array
         # TODO: improve using https://github.com/pytorch/pytorch/issues/13246#issuecomment-617140519
         dtype = [
-            ("sample_rate", "u2"),
+            ("sample_rate", "i"),
             ("num_frames", "i"),
             ("num_channels", "B"),
             ("bits_per_sample", "B"),
@@ -540,9 +539,8 @@ class Task(pl.LightningDataModule):
         prepared_data["annotated_duration"] = np.array(annotated_duration)
 
         # turn list of annotated regions into a single numpy array
-        dtype = [("file_id", "i"), ("duration", "f"), ("start", "f"), ("end", "f")]
-        annotated_regions_array = np.array(annotated_regions, dtype=dtype)
-        prepared_data["annotated_regions"] = annotated_regions_array
+        dtype = [("file_id", "i"), ("duration", "f"), ("start", "f")]
+        prepared_data["annotated_regions"] = np.array(annotated_regions, dtype=dtype)
 
         # convert annotated_classes (which is a list of list of classes, one list of classes per file)
         # into a single (num_files x num_classes) numpy array:
@@ -583,8 +581,8 @@ class Task(pl.LightningDataModule):
         # iterate over files in the validation subset
         for file_id in validation_file_ids:
             # get annotated regions in file
-            annotated_regions = annotated_regions_array[
-                annotated_regions_array["file_id"] == file_id
+            annotated_regions = prepared_data["annotated_regions"][
+                prepared_data["annotated_regions"]["file_id"] == file_id
             ]
 
             # iterate over annotated regions

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -285,9 +285,7 @@ class Task(pl.LightningDataModule):
                 # data was already created, do nothing
                 return
             # create a new cache directory at the path specified by the user
-            else:
-                cache_rep = Path(self.cache_path[: self.cache_path.rfind('/')])
-                cache_rep.mkdir(parents=True, exist_ok=True)
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
         # duration of training chunks
         # TODO: handle variable duration case
         duration = getattr(self, "duration", 0.0)
@@ -617,10 +615,13 @@ class Task(pl.LightningDataModule):
         if not self.has_setup_metadata:
             # if no cache directory was provided by the user and task data was not already prepared
             if self.cache_path is None and not self.has_prepared_data:
-                warnings.warn("""No path to the directory containing the cache of prepared data
-                              has been specified. Data preparation will therefore be carried out
-                              on each process used for training. To speed up data preparation, you
-                              can specify a cache directory when instantiating the task.""", stacklevel=1)
+                warnings.warn(
+                            "No path to the directory containing the cache of prepared data"
+                            "has been specified. Data preparation will therefore be carried out"
+                            "on each process used for training. To speed up data preparation, you"
+                            "can specify a cache directory when instantiating the task.",
+                            stacklevel=1
+                        )
                 self.prepare_data()
                 return
             # load data cached by prepare_data method into the task:
@@ -628,8 +629,10 @@ class Task(pl.LightningDataModule):
                 with open(self.cache_path, 'rb') as cache_file:
                     self.prepared_data = dict(np.load(cache_file, allow_pickle=True))
             except FileNotFoundError:
-                print("""Cached data for protocol not found. Ensure that prepare_data was
-                      executed correctly and that the path to the task cache is correct""")
+                print(
+                    "Cached data for protocol not found. Ensure that prepare_data was"
+                    "executed correctly and that the path to the task cache is correct"
+                )
                 raise
             self.has_setup_metadata = True
 
@@ -648,6 +651,8 @@ class Task(pl.LightningDataModule):
 
     @property
     def has_prepared_data(self):
+        # This flag indicates if data for this task was generated, and
+        # optionally saved on the disk
         return getattr(self, "_has_prepared_data", False)
 
     @has_prepared_data.setter
@@ -656,6 +661,8 @@ class Task(pl.LightningDataModule):
 
     @property
     def has_setup_metadata(self):
+        # This flag indicates if data was assigned to this task, directly from prepared
+        # data or by reading in a cached file on the disk
         return getattr(self, "_has_setup_metadata", False)
 
     @has_setup_metadata.setter

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -282,7 +282,7 @@ class Task(pl.LightningDataModule):
         if self.cache_path is not None:
             cache_path = Path(self.cache_path)
             if cache_path.exists():
-                # data was already created, do nothing
+                # data was already created, nothing to do
                 return
             # create a new cache directory at the path specified by the user
             cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -524,7 +524,9 @@ class Task(pl.LightningDataModule):
         dtype = [(key, "b") for key in metadata_unique_values]
 
         prepared_data["metadata"] = np.array(metadata, dtype=dtype)
+        metadata.clear()
         prepared_data["audios"] = np.array(audios, dtype=np.string_)
+        audios.clear()
 
         # turn list of files metadata into a single numpy array
         # TODO: improve using https://github.com/pytorch/pytorch/issues/13246#issuecomment-617140519
@@ -535,12 +537,16 @@ class Task(pl.LightningDataModule):
             ("bits_per_sample", "B"),
         ]
         prepared_data["audio_infos"] = np.array(audio_infos, dtype=dtype)
+        audio_infos.clear()
         prepared_data["audio_encodings"] = np.array(audio_encodings, dtype=np.string_)
+        audio_encodings.clear()
         prepared_data["annotated_duration"] = np.array(annotated_duration)
+        annotated_duration.clear()
 
         # turn list of annotated regions into a single numpy array
         dtype = [("file_id", "i"), ("duration", "f"), ("start", "f")]
         prepared_data["annotated_regions"] = np.array(annotated_regions, dtype=dtype)
+        annotated_regions.clear()
 
         # convert annotated_classes (which is a list of list of classes, one list of classes per file)
         # into a single (num_files x num_classes) numpy array:
@@ -554,6 +560,8 @@ class Task(pl.LightningDataModule):
         for file_id, classes in enumerate(annotated_classes):
             annotated_classes_array[file_id, classes] = True
         prepared_data["annotated_classes"] = annotated_classes_array
+        annotated_classes.clear()
+        del annotated_classes_array
 
         # turn list of annotations into a single numpy array
         dtype = [
@@ -566,7 +574,9 @@ class Task(pl.LightningDataModule):
         ]
 
         prepared_data["annotations"] = np.array(annotations, dtype=dtype)
+        annotations.clear()
         prepared_data["metadata_unique_values"] = metadata_unique_values
+        metadata_unique_values.clear()
 
         if self.has_validation:
             validation_chunks = list()
@@ -595,6 +605,7 @@ class Task(pl.LightningDataModule):
 
             dtype = [("file_id", "i"), ("start", "f"), ("duration", "f")]
             prepared_data["validation_chunks"] = np.array(validation_chunks, dtype=dtype)
+            validation_chunks.clear()
 
         self.prepared_data = prepared_data
         self.has_setup_metadata = True

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -522,7 +522,7 @@ class Task(pl.LightningDataModule):
             tuple(metadatum.get(key, -1) for key in metadata_unique_values)
             for metadatum in metadata
         ]
-        dtype = [(key, "i") for key in metadata_unique_values]
+        dtype = [(key, "b") for key in metadata_unique_values]
 
         prepared_data["metadata"] = np.array(metadata, dtype=dtype)
         prepared_data["audios"] = np.array(audios, dtype=np.string_)
@@ -530,10 +530,10 @@ class Task(pl.LightningDataModule):
         # turn list of files metadata into a single numpy array
         # TODO: improve using https://github.com/pytorch/pytorch/issues/13246#issuecomment-617140519
         dtype = [
-            ("sample_rate", "i"),
+            ("sample_rate", "u2"),
             ("num_frames", "i"),
-            ("num_channels", "i"),
-            ("bits_per_sample", "i"),
+            ("num_channels", "B"),
+            ("bits_per_sample", "B"),
         ]
         prepared_data["audio_infos"] = np.array(audio_infos, dtype=dtype)
         prepared_data["audio_encodings"] = np.array(audio_encodings, dtype=np.string_)

--- a/pyannote/audio/core/task.py
+++ b/pyannote/audio/core/task.py
@@ -27,7 +27,6 @@ import itertools
 import multiprocessing
 import numpy as np
 from pathlib import Path
-import pickle
 import sys
 import warnings
 from dataclasses import dataclass
@@ -602,14 +601,14 @@ class Task(pl.LightningDataModule):
 
         dtype = [("file_id", "i"), ("start", "f"), ("duration", "f")]
         prepared_data["validation_chunks"] = np.array(validation_chunks, dtype=dtype)
-        
+
         self.prepared_data = prepared_data
         self.has_setup_metadata = True
 
         # save preparated data on the disk
         if self.cache_path is not None:
             with open(self.cache_path, 'wb') as cache_file:
-                pickle.dump(prepared_data, cache_file)
+                np.savez_compressed(cache_file, **prepared_data)
 
         self.has_prepared_data = True
 
@@ -627,7 +626,7 @@ class Task(pl.LightningDataModule):
             # load data cached by prepare_data method into the task:
             try:
                 with open(self.cache_path, 'rb') as cache_file:
-                    self.prepared_data = pickle.load(cache_file)
+                    self.prepared_data = dict(np.load(cache_file, allow_pickle=True))
             except FileNotFoundError:
                 print("""Cached data for protocol not found. Ensure that prepare_data was
                       executed correctly and that the path to the task cache is correct""")

--- a/pyannote/audio/tasks/segmentation/mixins.py
+++ b/pyannote/audio/tasks/segmentation/mixins.py
@@ -138,8 +138,8 @@ class SegmentationTask(Task):
                 )
 
                 # select one chunk at random in this annotated region
-                _, _, start, end = self.prepared_data["annotated_regions"][annotated_region_index]
-                start_time = rng.uniform(start, end - duration)
+                _, region_duration, start = self.prepared_data["annotated_regions"][annotated_region_index]
+                start_time = rng.uniform(start, start + region_duration - duration)
 
                 yield self.prepare_chunk(file_id, start_time, duration)
 

--- a/pyannote/audio/tasks/segmentation/speaker_diarization.py
+++ b/pyannote/audio/tasks/segmentation/speaker_diarization.py
@@ -211,7 +211,7 @@ class SpeakerDiarization(SegmentationTask):
                 for region in annotated_regions:
                     # find annotations within current region
                     region_start = region["start"]
-                    region_end = region["end"]
+                    region_end = region["start"] + region["duration"]
                     region_annotations = annotations[
                         np.where(
                             (annotations["start"] >= region_start)


### PR DESCRIPTION
Instead of use `pickle`, in this PR, it is proposed to manage the reading and writing of job data to disk using:
- `np.savez_compressed` for writing on the disk
- `np.load` for reading from the cache

This PR also reduces memory usage by modifying types in `numpy array` and removing non-necessary entries. of these arrays.